### PR TITLE
fix(segments): fix the parsing of relative move to

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -463,7 +463,7 @@ function splitSegments(polygon) {
                         if (!position) {
                             position = c[0];
                         } else {
-                            position = coordAdd(c, position);
+                            position = coordAdd(c[0], position);
                         }
 
                         if (!start) {

--- a/test/segments.js
+++ b/test/segments.js
@@ -121,4 +121,11 @@ describe("Segments", function () {
         assert.equal(segs.some(function (seg) { return pointInSvgPolygon.isInside([198, 282], seg); }), false);
         assert.equal(segs.some(function (seg) { return pointInSvgPolygon.isInside([0, 0], seg); }), false);
     });
+
+    it("should support a relative move to after a first move to", function () {
+        var result = pointInSvgPolygon.segments("M270,38 m17,25 L10 12");
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].coords[0], [287, 63]);
+        assert.deepEqual(result[0].coords[1], [10, 12]);
+    });
 });


### PR DESCRIPTION
Before this patch, the result of the test would have been```
[
  '17,25270',
  NaN
]
```