### PR TITLE
fix(precision): fix arbitrary precision problem

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function toFloat(v) {
 }
 
 function coordEqual(c1, c2) {
-    return x(c1) === x(c2) && y(c1) === y(c2);
+    return Math.abs(x(c1) - x(c2)) < 1e-10 && Math.abs(y(c1) - y(c2)) < 1e-10;
 }
 
 function coordMax(c1, c2) {

--- a/test/segments.js
+++ b/test/segments.js
@@ -31,7 +31,7 @@ describe("Segments", function () {
 
     it("Handles implicite moveTo", function () {
         var result = pointInSvgPolygon.segments("m 212.5413,-8.3834813 52.39298,0 -1.02003,251.8031013 -49.92232,0 -1.45063,-251.8031013 z");
-        assert.equal(result.length, 5);
+        assert.equal(result.length, 4);
     });
 
     it("Handles implicite moveTo (relative)", function () {
@@ -127,5 +127,11 @@ describe("Segments", function () {
         assert.equal(result.length, 1);
         assert.deepEqual(result[0].coords[0], [287, 63]);
         assert.deepEqual(result[0].coords[1], [10, 12]);
+    });
+
+    it("should return true if the point is inside a rectangle, whatever the precision", function () {
+        var result = pointInSvgPolygon.segments("M 0 0 H360 V288 H 0 Z");
+        assert.equal(pointInSvgPolygon.isInside([88.741, 88.741], result), true);
+        assert.equal(pointInSvgPolygon.isInside([88.74, 88.74], result), true);
     });
 });


### PR DESCRIPTION
I'm very unlucky as I ran into this problem while using this (very useful BTW) lib.

This PR is one possible solution. There is others, but this solution is probably the simplest we can get, but in exchange, there is precision loss in the computation.

So it's your call if you want to merge or not.
If you don't want, can you give me some guidance on what solution you would prefer?

Below is the commit message
--- 

Sometimes, when we compare coordinates, we get 2 semantically equivalent
coordinates (e.g. .30000000004 and 0.3), but the `coordEqual` would
return false anyway because the coords are not exactly equals

I've made the hypothesis that nobody will ever need a precision greater
than 10 decimals.

The test `Handles implicite moveTo` was changed because the last 2
segments were semantically equivalent.